### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,5 +306,5 @@ iOS：apple store搜索clashmi、搜索sing-box、搜索Shadowrocket下载（更
 
 ## Star 历史
 
-![Star History Chart](https://api.star-history.com/svg?repos=KaWaIDeSuNe/xingjiabijichang&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=KaWaIDeSuNe/xingjiabijichang&type=Date)
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -235,4 +235,4 @@ None at the moment.
 
 ## 📈 Star History
 
-![Star History Chart](https://api.star-history.com/svg?repos=KaWaIDeSuNe/xingjiabijichang&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=KaWaIDeSuNe/xingjiabijichang&type=Date)


### PR DESCRIPTION
The star history chart in the README is currently broken: GitHub's stargazer API restrictions prevent the chart from rendering. This change updates the chart link in README.md and README_EN.md to a working alternative so the chart displays again.